### PR TITLE
Enable namespaced vars

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -14,9 +14,7 @@ function reverse(coll) {
 }
 
 function _reduce(f, init, coll) {
-    const ret = coll.reduce(f, init)
-    console.log(ret)
-    return ret
+    return coll.reduce(f, init)
 }
 
 function require(lib) {
@@ -71,7 +69,7 @@ function println() {
     const res = Array.prototype.map.call(arguments, function (exp) {
         return _pr_str(exp, false);
     }).join("")
-    console.log(res)
+    //console.log(res)
     return res
 }
 

--- a/src/env.js
+++ b/src/env.js
@@ -22,29 +22,18 @@ export function Env(outer, binds, exprs) {
     return this;
 }
 Env.prototype.find = function (key) {
-    /* if (!key.constructor || key.constructor.name !== 'Symbol') {
-        return "env.find key must be a symbol"
-    } */
-    // ignore namespaces
-    const k = key.value.split("/")[1] || key.value
+    // look for namespaced var, ignore if not found
+    const k = key.value || key.value.split("/")[1]
     if (k in this.data) { return this; }
     else if (this.outer) {  return this.outer.find(key); }
     else { return null; }
 };
 Env.prototype.set = function(key, value) {
-   /*  if (!key.constructor || key.constructor.name !== 'Symbol') {
-        console.log("key:", key)
-        return "env.set key must be a symbol"
-    } */
     this.data[key.value] = value;
     return value;
 };
 Env.prototype.get = function(key) {
-    /* if (!key.constructor || key.constructor.name !== 'Symbol') {
-        return "env.get key must be a symbol"
-    } */
-    // Ignore namespace prefixes
-    const k = key.value.split("/")[1] || key.value
+    const k = key.value || key.value.split("/")[1]
     var env = this.find(key);
     if (!env) { throw new Error("'" + k + "' not found"); }
     return env.data[k];

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -321,6 +321,7 @@ function _EVAL(ast, env) {
           //console.log("Calling single-arity function:", f)
           //console.log("ast:", ast)
           //console.log("args:", args)
+          //console.log("env:", env)
         }
         if (f.__ast__) {
           ast = f.__ast__;


### PR DESCRIPTION
Previously we were ignoring namespace prefixes by simply stripping them off. Mostly this is because the test suite is loaded into the same namespace as the source code but I want to mimic the behavior of a test namespace, that is with namespace aliases. This is because we have the ability to load libraries but no real require machinery.

This PR makes it so it first checks if the var is defined including the namespace if it has one. If not, it looks for the unprefixed var. This gives the best of both worlds, it will basically behave as if we have real namespaces, and the prefixed vars will not clobber names in the current env.